### PR TITLE
Avoid RuntimeError about object not initialized

### DIFF
--- a/data/usr/share/caja-python/extensions/caja-rename.py
+++ b/data/usr/share/caja-python/extensions/caja-rename.py
@@ -47,6 +47,8 @@ class RenameMenu(GObject.GObject, Caja.MenuProvider):
 
     def __init__(self):
 
+        GObject.Object.__init__(self)
+
         self.oPixBufFolder = Gtk.IconTheme().get_default().load_icon('gtk-directory', 22, 0)
         self.oPixBufFile = Gtk.IconTheme().get_default().load_icon('gtk-file', 22, 0)
 


### PR DESCRIPTION
E.g. https://bugs.launchpad.net/ubuntu/+source/caja-rename/+bug/1877718

```
$ caja
RuntimeError: object at 0x7fa8692f4fc0 of type RenameMenu is not initialized
```